### PR TITLE
Fix time unit bug in request duration.

### DIFF
--- a/lib/prome/rails.rb
+++ b/lib/prome/rails.rb
@@ -16,7 +16,7 @@ module Prome
         duration = ending - start
 
         Prome.get(:rails_requests_total).increment(labels)
-        Prome.get(:rails_request_duration_seconds).observe(labels, ms2s(duration))
+        Prome.get(:rails_request_duration_seconds).observe(labels, duration)
         Prome.get(:rails_view_runtime_seconds).observe(labels, ms2s(payload[:view_runtime]))
         Prome.get(:rails_db_runtime_seconds).observe(labels, ms2s(payload[:db_runtime]))
       end


### PR DESCRIPTION
Rails framework using ms as unit. However, for the request duration. Start time stamp - ending time stamp is result in a unit of second.